### PR TITLE
add options in init 'environment'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ fastify.register(
   require("fastify-sentry"),
   {
     dsn: "https://00000000000000000000000000000000@sentry.io/0000000",
+    environment: "local",
     errorHandler: (request, reply) => {
       // You can specify a custom behavior depending on the context of "request", generate a unique identifier etc.
       if (request.raw.url === "/") {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const Sentry = require("@sentry/node");
 
 async function sentryConnector(fastify, options) {
   Sentry.init({
-    dsn: options.dsn
+    dsn: options.dsn,
+    environment: options.environment
   });
   fastify.setErrorHandler((err, req, reply) => {
     Sentry.withScope(scope => {

--- a/test.js
+++ b/test.js
@@ -17,6 +17,7 @@ tap.test("fastify sentry error handler exist", test => {
 
   fastify.register(fastifySentry, {
     dsn: "https://00000000000000000000000000000000@sentry.io/0000000",
+    environment: "test",
     errorHandler: errorHandler
   });
 


### PR DESCRIPTION
I would like to add 'environment' to `Sentry.init` Option.

This is a function often required for Sentry users.