### PR TITLE
Adds support for releases

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ const Sentry = require("@sentry/node");
 function sentryConnector(fastify, options, done) {
   Sentry.init({
     dsn: options.dsn,
-    environment: options.environment ? options.environment : "local"
+    environment: options.environment ? options.environment : "local",
+    release: options.release
   });
   fastify.setErrorHandler((err, req, reply) => {
     Sentry.withScope(scope => {


### PR DESCRIPTION
Sentry `release` is part of the basic init options, refs:
- https://docs.sentry.io/platforms/javascript/#configure
- https://docs.sentry.io/product/releases/