### PR TITLE
The `ip` is now directly and only accessible from the request object

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function sentryConnector(fastify, options, done) {
   fastify.setErrorHandler((err, req, reply) => {
     Sentry.withScope(scope => {
       scope.setUser({
-        ip_address: req.raw.ip
+        ip_address: req.ip
       });
       scope.setTag("path", req.raw.url);
       // will be tagged with my-tag="my value"


### PR DESCRIPTION
The `modifyCoreObjects` went from defaulting to `true` to defaulting
to `false` and then got completely removed, refs:
https://github.com/fastify/fastify/pull/2015